### PR TITLE
Add new `maybe` ns

### DIFF
--- a/src/rp/condition/maybe.clj
+++ b/src/rp/condition/maybe.clj
@@ -1,0 +1,26 @@
+(ns rp.condition.maybe
+  (:import clojure.lang.ExceptionInfo))
+
+(defn ex-info?
+  [x]
+  (instance? ExceptionInfo x))
+
+(defn handle
+  [ok-fn error-fn x]
+  (if (ex-info? x)
+    (error-fn x)
+    (ok-fn x)))
+
+(defn pipeline
+  "Pass `init` data value into a pipeline of functions.
+   As soon as an ex-info is encountered, the pipeline will return it.
+   Otherwise the return value from each step function will be passed as the input into the
+   next function until all functions have been called, and the final result will be returned.
+
+   When there are no functions, simply returns `init`"
+  [[f & more-fs] init]
+  (if f
+    (handle (fn [x] (pipeline more-fs x))
+            (fn [e] e)
+            (f init))
+    init))

--- a/test/rp/condition/maybe_test.clj
+++ b/test/rp/condition/maybe_test.clj
@@ -1,0 +1,39 @@
+(ns rp.condition.maybe-test
+  (:require [clojure.test :refer :all]
+            [rp.condition.maybe :refer :all]))
+
+(deftest test-handle
+  (is (= 21
+         (handle (fn [n] (/ n 2))
+                 (fn [e] (ex-data e))
+                 42)))
+  (is (= 21
+         (handle (fn [{:keys [answer]}] (/ answer 2))
+                 (fn [e] (ex-data e))
+                 {:answer 42}))
+      "Should support destructuring")
+  (is (= :bears
+         (handle (fn [n] "We could have been great together.")
+                 (fn [e] (:type (ex-data e)))
+                 (ex-info "Bad news" {:type :bears}))))
+  (is (= :null-and-void
+         (handle (fn [n] (if-not n
+                           :null-and-void
+                           (/ n 2)))
+                 (fn [e] (ex-data e))
+                 nil))
+      "A nil value is ok; only ExceptionInfo objects are considered errors."))
+
+(deftest test-pipeline
+  (let [init 5]
+    (is (= init (pipeline [] init)))
+    (is (= init (pipeline nil init)))
+
+    (let [inc-step (fn [n] (inc n))
+          double-step (fn [n] (* 2 n))
+          ex (ex-info "Oh no" {:foo "bar"})
+          err-step (fn [n] ex)]
+      (is (= 13
+             (pipeline [inc-step double-step inc-step] init)))
+      (is (= ex
+             (pipeline [inc-step double-step err-step inc-step] init))))))


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/Boards/View/516315009)

Similar to `rp.condition.result`, but you don't have to construct `Result`
objects to use it. Any old value can be handled. You still have to create an 
`ExceptionInfo` object to indicate an error, but there's no need to wrap it in a `Result`.

This in an alternative approach to https://github.com/rentpath/rp-condition-clj/pull/5