### PR TITLE
SB 516315009 replace result with bare value or error value implementing error protocol

### DIFF
--- a/src/rp/condition/maybe.clj
+++ b/src/rp/condition/maybe.clj
@@ -1,0 +1,39 @@
+(ns rp.condition.maybe)
+
+(defprotocol IError
+  (error-data [this]))
+
+(defrecord ErrorImpl [data]
+  IError
+  (error-data [this] data))
+
+(defn make-error
+  "Make an IError from anything.
+   `data` can be whatever type you like (map, keyword, whatever).
+   Choose your own conventions for error payloads."
+  [data]
+  (->ErrorImpl data))
+
+(defn error?
+  [x]
+  (satisfies? IError x))
+
+(defn handle
+  [ok-fn error-fn x]
+  (if (error? x)
+    (error-fn x)
+    (ok-fn x)))
+
+(defn pipeline
+  "Pass `init` data value into a pipeline of functions.
+   As soon as an error is encountered, the pipeline will return it.
+   Otherwise the return value from each step function will be passed as the input into the
+   next function until all functions have been called, and the final result will be returned.
+
+   When there are no functions, simply returns `init`"
+  [[f & more-fs] init]
+  (if f
+    (handle (fn [x] (pipeline more-fs x))
+            (fn [e] e)
+            (f init))
+    init))

--- a/test/rp/condition/maybe_test.clj
+++ b/test/rp/condition/maybe_test.clj
@@ -1,0 +1,39 @@
+(ns rp.condition.maybe-test
+  (:require [clojure.test :refer :all]
+            [rp.condition.maybe :refer :all]))
+
+(deftest test-handle
+  (is (= 21
+         (handle (fn [n] (/ n 2))
+                 (fn [e] (error-data e))
+                 42)))
+  (is (= 21
+         (handle (fn [{:keys [answer]}] (/ answer 2))
+                 (fn [e] (error-data e))
+                 {:answer 42}))
+      "Should support destructuring")
+  (is (= :bears
+         (handle (fn [n] "We could have been great together.")
+                 (fn [e] (:type (error-data e)))
+                 (make-error {:type :bears}))))
+  (is (= :null-and-void
+         (handle (fn [n] (if-not n
+                           :null-and-void
+                           (/ n 2)))
+                 (fn [e] (error-data e))
+                 nil))
+      "A nil value is ok; only objects satisfying IError are considered errors."))
+
+(deftest test-pipeline
+  (let [init 5]
+    (is (= init (pipeline [] init)))
+    (is (= init (pipeline nil init)))
+
+    (let [inc-step (fn [n] (inc n))
+          double-step (fn [n] (* 2 n))
+          err (make-error "Boom!")
+          err-step (fn [n] err)]
+      (is (= 13
+             (pipeline [inc-step double-step inc-step] init)))
+      (is (= err
+             (pipeline [inc-step double-step err-step inc-step] init))))))


### PR DESCRIPTION
Did this in the bg while waiting for builds to run.
No rush to review (the parent PR #6 has been open for quite a while).
This uses a protocol-based approach like I mentioned in a comment on that PR.
Provides a factory function (`make-error`) to make an error out of anything; no more bloated exceptions needed.